### PR TITLE
Generate CSV of the provider inventory

### DIFF
--- a/index_includes/data-inventory.html
+++ b/index_includes/data-inventory.html
@@ -1,6 +1,7 @@
 <div class="usa-grid">
   <h3>Data Inventory</h3>
   <p>Use curated data related to opportunity from across federal and local governments.</p>
+  <p><a href="{{ site.baseurl }}/inventory.csv">Download this inventory</a> as a flattened .csv file</p>
 </div>
 
 <div class="usa-grid">

--- a/inventory.csv
+++ b/inventory.csv
@@ -1,12 +1,17 @@
 ---
 ---
-provider_name,provider_url,category,description,url
+{% capture csv %}
+{% assign replace = "$$" %}
+{% capture newline %}
+{% endcapture %}
+provider_name,provider_url,category,description,url{{ replace }}
 {% for pid in site.data.data-providers %}
 {% assign provider = pid[1] %}
 {% for dataset in provider.datasets %}
 {% if dataset.topic %} {% capture category %}{{ dataset.topic }}{% endcapture %}
 {% elsif dataset.curator %} {% capture category %}{{ dataset.curator }}{% endcapture %}
 {% endif %}
-"{{ provider.name }}",{{ provider.url }},"{{ category }}","{{ dataset.description }}",{{ dataset.url }}
+"{{ provider.name }}",{{ provider.url }},"{{ category }}","{{ dataset.description }}",{{ dataset.url }}{{ replace }}
 {% endfor %}
 {% endfor %}
+{% endcapture %}{{ csv | strip_newlines | replace: replace, newline }}

--- a/inventory.csv
+++ b/inventory.csv
@@ -1,9 +1,12 @@
 ---
 ---
-provider_name,provider_url,dataset_topic,dataset_description,dataset_url
+provider_name,provider_url,category,description,url
 {% for pid in site.data.data-providers %}
 {% assign provider = pid[1] %}
 {% for dataset in provider.datasets %}
-"{{ provider.name }}",{{ provider.url }},"{{ dataset.topic }}","{{ dataset.description }}",{{ dataset.url }}
+{% if dataset.topic %} {% capture category %}{{ dataset.topic }}{% endcapture %}
+{% elsif dataset.curator %} {% capture category %}{{ dataset.curator }}{% endcapture %}
+{% endif %}
+"{{ provider.name }}",{{ provider.url }},"{{ category }}","{{ dataset.description }}",{{ dataset.url }}
 {% endfor %}
 {% endfor %}

--- a/inventory.csv
+++ b/inventory.csv
@@ -1,0 +1,9 @@
+---
+---
+provider_name,provider_url,dataset_topic,dataset_description,dataset_url
+{% for pid in site.data.data-providers %}
+{% assign provider = pid[1] %}
+{% for dataset in provider.datasets %}
+"{{ provider.name }}",{{ provider.url }},"{{ dataset.topic }}","{{ dataset.description }}",{{ dataset.url }}
+{% endfor %}
+{% endfor %}


### PR DESCRIPTION
This is an attempt at #52, with a few caveats:

 - Flattened each of the providers' datasets with provider info (there's some duplicated info per record)

 - Combined Federal `curator` and City `topic` fields into a generic `category` field

 - The generated CSV contains *many* blank lines (artifact of jekyll/liquid templating)

 - Liquid `for` [only supports 50 iterations](https://docs.shopify.com/themes/liquid/tags/iteration-tags#for) per "page"; I'm not sure how to deal with this when generating a data file. This implies a limit of 50 providers, each with a limit of 50 datasets (2 `for` loops in this implementation)

I'm happy to fold in any comments/suggestions...