### PR TITLE
URL update

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Expanding Opportunity with Open Data
 
-http://uscensusbureau.github.io/opportunity/
+http://opportunity.census.gov
 
 
 ### Public domain


### PR DESCRIPTION
After #56 was merged, I realized that the [`inventory.csv`](http://opportunity.census.gov/inventory.csv) link doesn't work if you're viewing the site from the [default GitHub pages URL](http://uscensusbureau.github.io/opportunity/).

One option is to modify the `baseUrl` property in `_config.yml`, but this could impact the site on the CNAMEd-domain. 

Another option is to just not advertise the GitHub pages default URL :smile: 

I would also recommend editing the repository description area to include the CNAME URL:

![image](https://cloud.githubusercontent.com/assets/1783439/14114797/5cc34058-f58d-11e5-9e97-bc4c5bcb8c7b.png)
